### PR TITLE
improve: GithubActionによるビルドテストの速度を改善

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -27,12 +27,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            node_modules
-            .next
             ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+            ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx', '!node_modules/**/*') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-
+            ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-
 
       - name: Install Dependencies
         run: pnpm install


### PR DESCRIPTION
* Github Action内で`.next/cache`をキャッシュするように変更し、`next build`の実行時間を短縮